### PR TITLE
feat: some nix black magic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Data file
 config.toml
+
+/result

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,6 @@ in
     src = ./.;
 
     denoDepsHash = lib.fakeHash;
-    binaryEntrypointPath = "./mod.ts";
+    binaryEntrypointPath = "./main.ts";
     permissions.allow.all = true;
   }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "deno-fetcher": {
+      "locked": {
+        "lastModified": 1761042771,
+        "narHash": "sha256-17HD3Jc0EQ50NOSBAwama3apyMhlTYQ1LxVM3xCipI4=",
+        "owner": "aMOPel",
+        "repo": "nixpkgs",
+        "rev": "5ea49496373a00cc0019f13070b4e01c1ed540ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aMOPel",
+        "ref": "feat/fetchDenoDeps",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -70,6 +86,7 @@
     },
     "root": {
       "inputs": {
+        "deno-fetcher": "deno-fetcher",
         "flake-utils": "flake-utils",
         "nix-deno": "nix-deno",
         "nixpkgs": "nixpkgs_2"

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/4l4bvyx578788kz687c7h071b2kgba5i--0.0.1


### PR DESCRIPTION
requires deno compilation because of https://github.com/NixOS/nixpkgs/blob/ddf56acbeb53825b79b82c13a657806774bfd137/pkgs/by-name/de/deno/package.nix#L210

relies on https://github.com/aMOPel/nixpkgs/tree/feat/fetchDenoDeps and https://github.com/NixOS/nixpkgs/pull/453904 to fetch deno.lock dependencies and needs to switch to upstream nixpkgs once pr merges

relies on https://github.com/nekowinston/nix-deno for building and other stuff. too lazy to get rid of it for now